### PR TITLE
Add Mathematica package SparseRREF.wl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,7 +405,11 @@ FodyWeavers.xsd
 
 # Windows Executable files
 *.exe
+
+# Shared libraries
 *.dll
+*.so
+*.dylib
 
 # Windows Batch files
 *.bat
@@ -414,5 +418,5 @@ FodyWeavers.xsd
 # VS Code settings
 .vscode/
 
-# Mathematica Header files
-mma/
+# JetBrains CLion settings
+.idea/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Example usage:
 Needs["SparseRREF`", "/path/to/SparseRREF.m"];
 mat = SparseArray @ { {1, 0}, {1/2, 1/3} };
 rref = RationalRREF[mat];
-{rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Threads -> $ProcessorCount];
+{rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Method -> 1, Threads -> $ProcessorCount];
 ```
 
 To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).

--- a/README.md
+++ b/README.md
@@ -111,17 +111,23 @@ The Mathematica package [SparseRREF.m](SparseRREF.m) allows to call functions ex
 
 Example usage:
 ```mathematica
+(* Needs["SparseRREF`"]; *)
 Needs["SparseRREF`", "/path/to/SparseRREF.m"];
-mat = SparseArray @ { {1, 0}, {1/2, 1/3} };
+
+mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
 rref = RationalRREF[mat];
 {rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Method -> 1, Threads -> $ProcessorCount];
+
+mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
+p = 7;
+{rref, kernel} = ModRREF[mat, p, OutputMode -> 1, Threads -> $ProcessorCount];
 ```
 
 To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).
 
 See comments in [SparseRREF.m](SparseRREF.m) for more details.
 
-**TODO**: Currently, the package contains only the function `RationalRREF[]`.
+**TODO**: Currently, the package contains only the functions `RationalRREF[]` and `ModRREF[]`.
 
 ### BenchMark
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Needs["SparseRREF`"];
 
 mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
 rref = RationalRREF[mat];
-{rref, kernel, pivots} = RationalRREF[mat, "OutputMode" -> 3, "Method" -> 1, "Threads" -> $ProcessorCount];
+{rref, kernel, pivots} = RationalRREF[mat, "OutputMode" -> 3, "Method" -> "Right", "Threads" -> $ProcessorCount];
 
 mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
 p = 7;

--- a/README.md
+++ b/README.md
@@ -111,16 +111,16 @@ The Mathematica package [SparseRREF.m](SparseRREF.m) allows to call functions ex
 
 Example usage:
 ```mathematica
-(* Needs["SparseRREF`"]; *)
-Needs["SparseRREF`", "/path/to/SparseRREF.m"];
+Needs["SparseRREF`"];
+(* or: Needs["SparseRREF`", "/path/to/SparseRREF.m"]; *)
 
 mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
 rref = RationalRREF[mat];
-{rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Method -> 1, Threads -> $ProcessorCount];
+{rref, kernel, pivots} = RationalRREF[mat, "OutputMode" -> 3, "Method" -> 1, "Threads" -> $ProcessorCount];
 
 mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
 p = 7;
-{rref, kernel} = ModRREF[mat, p, OutputMode -> 1, Threads -> $ProcessorCount];
+{rref, kernel} = ModRREF[mat, p, "OutputMode" -> 1, "Threads" -> $ProcessorCount];
 ```
 
 To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Standalone executable:
 g++ main.cpp -o sparserref -O3 -std=c++20 -I$INCULDE -L$LIB -lflint -lgmp
 ```
 
-Shared library for [Wolfram LibraryLink](https://reference.wolfram.com/language/guide/LibraryLink.html) API (used by Mathematica package [SparseRREF.m](SparseRREF.m), see below):
+Shared library for [Wolfram LibraryLink](https://reference.wolfram.com/language/guide/LibraryLink.html) API (used by Mathematica package [SparseRREF.wl](SparseRREF.wl), see below):
 ```bash
 g++ mma_link.cpp -fPIC -shared -O3 -std=c++20 -o mathlink.dll -I$MATHEMATICA_HOME/SystemFiles/IncludeFiles/C -I$INCLUDE -L$LIB -lflint -lgmp
 ```
@@ -107,12 +107,12 @@ The main function is `sparse_mat_rref`, its output is its pivots, and it modifie
 
 #### Mathematica API
 
-The Mathematica package [SparseRREF.m](SparseRREF.m) allows to call functions exported in [mma_link.cpp](mma_link.cpp):
+The Mathematica package [SparseRREF.wl](SparseRREF.wl) allows to call functions exported in [mma_link.cpp](mma_link.cpp):
 
 Example usage:
 ```mathematica
 Needs["SparseRREF`"];
-(* or: Needs["SparseRREF`", "/path/to/SparseRREF.m"]; *)
+(* or: Needs["SparseRREF`", "/path/to/SparseRREF.wl"]; *)
 
 mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
 rref = SparseRREF[mat];
@@ -123,9 +123,9 @@ p = 7;
 {rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];
 ```
 
-To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).
+To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.wl](SparseRREF.wl).
 
-See comments in [SparseRREF.m](SparseRREF.m) for more details.
+See comments in [SparseRREF.wl](SparseRREF.wl) for more details.
 
 ### BenchMark
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Needs["SparseRREF`"];
 
 mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
 rref = RationalRREF[mat];
-{rref, kernel, pivots} = RationalRREF[mat, "OutputMode" -> 3, "Method" -> "Right", "Threads" -> $ProcessorCount];
+{rref, kernel, pivots} = RationalRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "Threads" -> $ProcessorCount];
 
 mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
 p = 7;
-{rref, kernel} = ModRREF[mat, p, "OutputMode" -> 1, "Threads" -> $ProcessorCount];
+{rref, kernel} = ModRREF[mat, p, "OutputMode" -> "RREF,Kernel", "Threads" -> $ProcessorCount];
 ```
 
 To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).

--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ Example usage:
 Needs["SparseRREF`"];
 (* or: Needs["SparseRREF`", "/path/to/SparseRREF.wl"]; *)
 
+(* rationals *)
 mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
 rref = SparseRREF[mat];
-{rref, kernel, pivots} = SparseRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "Threads" -> $ProcessorCount];
+{rref, kernel, pivots} = SparseRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "BackwardSubstitution" -> True, "Threads" -> $ProcessorCount, "Verbose" -> True, "PrintStep" -> 10];
 
+(* integers mod p *)
 mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
 p = 7;
 {rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];

--- a/README.md
+++ b/README.md
@@ -115,19 +115,17 @@ Needs["SparseRREF`"];
 (* or: Needs["SparseRREF`", "/path/to/SparseRREF.m"]; *)
 
 mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
-rref = RationalRREF[mat];
-{rref, kernel, pivots} = RationalRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "Threads" -> $ProcessorCount];
+rref = SparseRREF[mat];
+{rref, kernel, pivots} = SparseRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "Threads" -> $ProcessorCount];
 
 mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
 p = 7;
-{rref, kernel} = ModRREF[mat, p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];
+{rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];
 ```
 
 To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).
 
 See comments in [SparseRREF.m](SparseRREF.m) for more details.
-
-**TODO**: Currently, the package contains only the functions `RationalRREF[]` and `ModRREF[]`.
 
 ### BenchMark
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ rref = RationalRREF[mat];
 
 mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
 p = 7;
-{rref, kernel} = ModRREF[mat, p, "OutputMode" -> "RREF,Kernel", "Threads" -> $ProcessorCount];
+{rref, kernel} = ModRREF[mat, p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];
 ```
 
 To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ----
 
-This head only library intends to compute the exact RREF with row and column permutations of a sparse matrix over finite field or rational field, which is a common problem in linear algebra, and is widely used for number theory, cryptography, theoretical physics, etc.. The code is based on the FLINT library, which is a C library for number theory. 
+This header-only library intends to compute the exact RREF with row and column permutations of a sparse matrix over finite field or rational field, which is a common problem in linear algebra, and is widely used for number theory, cryptography, theoretical physics, etc.. The code is based on the FLINT library, which is a C library for number theory. 
 
 Some algorithms are inspired by [Spasm](https://github.com/cbouilla/spasm), but we do not depend on it. The algorithm here is definite (Spasm is random), so once the parameters are given, the result is stable, which is important for some purposes. 
 
@@ -25,20 +25,20 @@ If one use functions on sparse_tensor, it also requires to link tbb (Threading B
 
 For a sparse matrix $M$, the code computes its RREF $\Lambda$ with row and column permutations. Instead of permute the row and column directly, we keep the row and column ordering of the matrix, i.e. the i-th row/column of $\Lambda$ is the i-th row/column of $M$, and the row and column permutation of this RREF is implicitly given by its pivots, which is a list of pairs of (row,col). In the ordering of pivots, the submatrix $\Lambda[\text{rows in pivots},\text{cols in pivots}]$ of $\Lambda$ is an identity matrix (if `--no-backward-substitution` is enabled, it is upper triangular). 
 
-### How to use compile code
+### How to compile the code
 
 We now only support the rational field $\mathbb Q$ and the $\mathbb Z/p\mathbb Z$, where $p$ is a prime less than $2^{\texttt{BIT}-1}$ (it's $2^{63}$ on a 64-bit machine), but it is possible to generalize to other fields/rings by some small modification.
 
 It is recommended to use [mimalloc](https://github.com/microsoft/mimalloc) (or other similar library) to dynamically override the standard malloc, especially on Windows.
 
-We also provide an example, see `mma_link.cpp`, by using the LibraryLink api of Mathematica to compile a library which can used by Mathematica.
+Example build commands (also add `-lpthread` if pthread is required by the compiler):
 
-Build it, e.g. (also add `-lpthread` if pthread is required by the compiler)
-
+Standalone executable:
 ```bash
 g++ main.cpp -o sparserref -O3 -std=c++20 -I$INCULDE -L$LIB -lflint -lgmp
 ```
 
+Shared library for [Wolfram LibraryLink](https://reference.wolfram.com/language/guide/LibraryLink.html) API (used by Mathematica package [SparseRREF.m](SparseRREF.m), see below):
 ```bash
 g++ mma_link.cpp -fPIC -shared -O3 -std=c++20 -o mathlink.dll -I$MATHEMATICA_HOME/SystemFiles/IncludeFiles/C -I$INCLUDE -L$LIB -lflint -lgmp
 ```
@@ -47,7 +47,9 @@ and `$MATHEMATICA_HOME/SystemFiles/IncludeFiles/C` is the path of Mathematica C 
 
 ### How to use the code
 
-The `main.cpp` is an example to use the head only library, the help is
+#### Standalone executable
+
+The file [main.cpp](main.cpp) is an example to use the header-only library, the help is
 
 ```
 Usage: SparseRREF [--help] [--version] [--output VAR]
@@ -103,6 +105,24 @@ The last line is a dummy line, which is used to indicate the end of the matrix.
 
 The main function is `sparse_mat_rref`, its output is its pivots, and it modifies the input matrix $M$ to its RREF $\Lambda$.
 
+#### Mathematica API
+
+The Mathematica package [SparseRREF.m](SparseRREF.m) allows to call functions exported in [mma_link.cpp](mma_link.cpp):
+
+Example usage:
+```mathematica
+Needs["SparseRREF`", "/path/to/SparseRREF.m"];
+mat = SparseArray @ { {1, 0}, {1/2, 1/3} };
+rref = RationalRREF[mat];
+{rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Threads -> $ProcessorCount];
+```
+
+To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.m](SparseRREF.m).
+
+See comments in [SparseRREF.m](SparseRREF.m) for more details.
+
+**TODO**: Currently, the package contains only the function `RationalRREF[]`.
+
 ### BenchMark
 
 We compare it with [Spasm](https://github.com/cbouilla/spasm). Platform and Configuration: 
@@ -139,4 +159,5 @@ SparseRREF uses less memory than Spasm since its result has less non zero values
 * Improve the algorithms.
 * Add PLUQ decomposition.
 * Add more fields/rings.
+* Add more functions and parameters to Mathematica API
 

--- a/SparseRREF.m
+++ b/SparseRREF.m
@@ -1,0 +1,82 @@
+(* ::Package:: *)
+
+(* 
+  Mathematica interface for SparseRREF library.
+  SparseRREF is a C++ library that computes exact RREF with row and column permutations of a sparse matrix over finite field or rational field.
+  See details at https://github.com/munuxi/SparseRREF
+  
+  Prerequisites:
+  - Compile mma_link.cpp to shared library mathlink.$EXT ($EXT = "dll" on Windows, "so" on Linux, "dylib" on macOS)
+  - Store SparseRREF.m in the same directory.
+
+  Available functions:
+  - RationalRREF
+
+  Example usage:
+    (* Needs["SparseRREF`"]; *)
+    Needs["SparseRREF`", "/path/to/SparseRREF.m"];
+    mat = SparseArray @ { {1, 0}, {1/2, 1/3} };
+    rref = RationalRREF[mat];
+    {rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Threads -> $ProcessorCount];
+*)
+
+BeginPackage["SparseRREF`"];
+
+
+Options[RationalRREF] = {
+  OutputMode -> 0,
+  Threads -> 1
+};
+
+RationalRREF::usage =
+  "RationalRREF[mat, opts] computes the exact RREF of a sparse rational matrix. " <>
+  "Default options: " <> ToString @ Options @ RationalRREF;
+
+SyntaxInformation[RationalRREF] = {"ArgumentsPattern" -> {_, OptionsPattern[]}}
+
+(* TODO: use meaningful names instead of integers*)
+OutputMode::usage =
+  "Output mode for RationalRREF:
+  0: rref
+  1: {rref, kernel}
+  2: {rref, pivots}
+  3: {rref, kernel, pivots}";
+
+Threads::usage = "Number of threads used by SparseRREF functions.";
+
+
+Begin["`Private`"];
+
+$sparseRREFDirectory = DirectoryName[$InputFileName];
+
+$sparseRREFLib = FindLibrary @ FileNameJoin @ {$sparseRREFDirectory, "mathlink"};
+
+(* TODO: error message if $sparseRREFLib == $Failed *)
+
+(* TODO: load other mathlink functions: modpmatmul, modrref, ratmat_inv *)
+
+$rationalRREFLibFunction =
+  LibraryFunctionLoad[
+    $sparseRREFLib,
+    "rational_rref",
+    {
+      {LibraryDataType[ByteArray], "Constant"},
+      Integer,
+      Integer
+    },
+    {LibraryDataType[ByteArray], Automatic}
+  ];
+
+RationalRREF[mat_SparseArray, opts : OptionsPattern[] ] :=
+  BinaryDeserialize @
+    $rationalRREFLibFunction[
+      BinarySerialize[mat],
+      OptionValue[OutputMode],
+      OptionValue[Threads]
+    ];
+
+End[];
+
+Protect[RationalRREF, OutputMode, Threads];
+
+EndPackage[];

--- a/SparseRREF.m
+++ b/SparseRREF.m
@@ -17,7 +17,7 @@
     Needs["SparseRREF`", "/path/to/SparseRREF.m"];
     mat = SparseArray @ { {1, 0}, {1/2, 1/3} };
     rref = RationalRREF[mat];
-    {rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Threads -> $ProcessorCount];
+    {rref, kernel, pivots} = RationalRREF[mat, OutputMode -> 3, Method -> 1, Threads -> $ProcessorCount];
 *)
 
 BeginPackage["SparseRREF`"];
@@ -25,6 +25,13 @@ BeginPackage["SparseRREF`"];
 
 Options[RationalRREF] = {
   OutputMode -> 0,
+  (* Pivot search method:
+    0: right and left search
+    1: only right search
+    2: hybrid
+    NB: we don't define SparseRREF`Method to avoid collisions with System`Method
+  *)
+  Method -> 0,
   Threads -> 1
 };
 
@@ -62,6 +69,7 @@ $rationalRREFLibFunction =
     {
       {LibraryDataType[ByteArray], "Constant"},
       Integer,
+      Integer,
       Integer
     },
     {LibraryDataType[ByteArray], Automatic}
@@ -72,6 +80,7 @@ RationalRREF[mat_SparseArray, opts : OptionsPattern[] ] :=
     $rationalRREFLibFunction[
       BinarySerialize[mat],
       OptionValue[OutputMode],
+      OptionValue[Method],
       OptionValue[Threads]
     ];
 

--- a/SparseRREF.m
+++ b/SparseRREF.m
@@ -90,15 +90,6 @@ $rationalRREFLibFunction =
     {LibraryDataType[ByteArray], Automatic}
   ];
 
-RationalRREF[mat_SparseArray, opts : OptionsPattern[] ] :=
-  BinaryDeserialize @
-    $rationalRREFLibFunction[
-      BinarySerialize[mat],
-      OptionValue["OutputMode"],
-      OptionValue["Method"],
-      OptionValue["Threads"]
-    ];
-
 $modRREFLibFunction = 
   LibraryFunctionLoad[
     $sparseRREFLib,
@@ -111,6 +102,15 @@ $modRREFLibFunction =
     },
     {LibraryDataType[SparseArray], Automatic}
   ];
+
+RationalRREF[mat_SparseArray, opts : OptionsPattern[] ] :=
+  BinaryDeserialize @
+    $rationalRREFLibFunction[
+      BinarySerialize[mat],
+      OptionValue["OutputMode"],
+      OptionValue["Method"],
+      OptionValue["Threads"]
+    ];
 
 ModRREF[mat_SparseArray, p_?IntegerQ, opts : OptionsPattern[] ] := 
   With[

--- a/SparseRREF.m
+++ b/SparseRREF.m
@@ -28,6 +28,8 @@
 
 BeginPackage["SparseRREF`"];
 
+Unprotect["SparseRREF`*"];
+
 
 Options[RationalRREF] = {
   OutputMode -> 0,
@@ -135,8 +137,10 @@ ModRREF[mat_SparseArray, p_?IntegerQ, opts : OptionsPattern[] ] :=
     ]
   ];
 
-End[];
+With[{syms = Names["SparseRREF`*"]},
+  SetAttributes[syms, {Protected, ReadProtected}]
+];  
 
-Protect[RationalRREF, ModRREF, OutputMode, Threads];
+End[];
 
 EndPackage[];

--- a/SparseRREF.wl
+++ b/SparseRREF.wl
@@ -98,10 +98,10 @@ modRREFLibFunction =
     "modrref",
     {
       {LibraryDataType[SparseArray], "Constant"},
-      {Integer},
-      {Integer},
-      {Integer},
-      {Integer}
+      Integer,
+      Integer,
+      Integer,
+      Integer
     },
     {LibraryDataType[SparseArray], Automatic}
   ];

--- a/SparseRREF.wl
+++ b/SparseRREF.wl
@@ -58,6 +58,7 @@ SparseRREF::usage =
 
 SyntaxInformation[SparseRREF] = {"ArgumentsPattern" -> {_, OptionsPattern[]}}
 
+SparseRREF::findlib = "SparseRREF library \"`1`\" not found at `2`";
 SparseRREF::optionvalue = "Invalid SparseRREF option value: `1` -> `2`. Allowed values: `3`";
 SparseRREF::rettype = "SparseRREF should return SparseArray or List, but returned: `1`"
 
@@ -66,12 +67,17 @@ Begin["`Private`"];
 (* Load SparseRREF library *)
 
 $sparseRREFDirectory = DirectoryName[$InputFileName];
+(* TODO rename e.g. to SparseRREF_MMA or SparseRREF_LibraryLink *)
+$sparseRREFLibName = "mathlink";
 
-$sparseRREFLib = FindLibrary @ FileNameJoin @ {$sparseRREFDirectory, "mathlink"};
+(* TODO: shall we search in all directories from $LibraryPath? *)
+$sparseRREFLib = FindLibrary @ FileNameJoin @ {$sparseRREFDirectory, $sparseRREFLibName};
 
-(* TODO: error message if $sparseRREFLib == $Failed *)
+If[FailureQ[$sparseRREFLib],
+  Message[SparseRREF::findlib, $sparseRREFLibName, $sparseRREFDirectory];
+];
 
-(* TODO: load other exported functions: modpmatmul, ratmat_inv *)
+(* TODO: provide API for other exported functions: modpmatmul, ratmat_inv *)
 
 rationalRREFLibFunction =
   LibraryFunctionLoad[

--- a/SparseRREF.wl
+++ b/SparseRREF.wl
@@ -7,7 +7,7 @@
   
   Prerequisites:
   - Compile mma_link.cpp to shared library mathlink.$EXT ($EXT = "dll" on Windows, "so" on Linux, "dylib" on macOS)
-  - Store SparseRREF.m in the same directory.
+  - Store SparseRREF.wl in the same directory.
 
   Available functions:
   - SparseRREF
@@ -29,7 +29,7 @@
 
   Example usage:
     Needs["SparseRREF`"];
-    (* or: Needs["SparseRREF`", "/path/to/SparseRREF.m"]; *)
+    (* or: Needs["SparseRREF`", "/path/to/SparseRREF.wl"]; *)
     
     mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
     rref = SparseRREF[mat];

--- a/mma_link.cpp
+++ b/mma_link.cpp
@@ -157,12 +157,13 @@ EXTERN_C DLLEXPORT int modpmatmul(WolframLibraryData ld, mint Argc, MArgument* A
 }
 
 EXTERN_C DLLEXPORT int modrref(WolframLibraryData ld, mint Argc, MArgument *Args, MArgument Res) {
-	if (Argc != 4)
+	if (Argc != 5)
 		return LIBRARY_FUNCTION_ERROR;
 	auto mat = MArgument_getMSparseArray(Args[0]);
 	auto p = MArgument_getInteger(Args[1]);
 	auto output_kernel = MArgument_getInteger(Args[2]);
-	auto nthreads = MArgument_getInteger(Args[3]);
+	auto method = MArgument_getInteger(Args[3]);
+	auto nthreads = MArgument_getInteger(Args[4]);
 
 	auto sf = ld->sparseLibraryFunctions;
 
@@ -176,6 +177,7 @@ EXTERN_C DLLEXPORT int modrref(WolframLibraryData ld, mint Argc, MArgument *Args
 	field_t F(FIELD_Fp, p);
 
 	rref_option_t opt;
+	opt->method = method;
 	opt->pool.reset(nthreads);
 
 	auto pivots = sparse_mat_rref(A, F, opt);

--- a/mma_link.cpp
+++ b/mma_link.cpp
@@ -207,11 +207,12 @@ EXTERN_C DLLEXPORT int modrref(WolframLibraryData ld, mint Argc, MArgument *Args
 // 2: output the rref and its pivots
 // 3: output the rref, kernel and pivots
 EXTERN_C DLLEXPORT int rational_rref(WolframLibraryData ld, mint Argc, MArgument* Args, MArgument Res) {
-	if (Argc != 3)
+	if (Argc != 4)
 		return LIBRARY_FUNCTION_ERROR;
 	auto na_in = MArgument_getMNumericArray(Args[0]);
 	auto output_mode = MArgument_getInteger(Args[1]);
-	auto nthreads = MArgument_getInteger(Args[2]);
+	auto method = MArgument_getInteger(Args[2]);
+	auto nthreads = MArgument_getInteger(Args[3]);
 
 	numericarray_data_t type = MNumericArray_Type_Undef;
 	auto naFuns = ld->numericarrayLibraryFunctions;
@@ -237,6 +238,7 @@ EXTERN_C DLLEXPORT int rational_rref(WolframLibraryData ld, mint Argc, MArgument
 		auto mat = sparse_mat_read_wxf<rat_t, int>(parser.tokens, F);
 
 		rref_option_t opt;
+		opt->method = method;
 		opt->pool.reset(nthreads);
 
 		std::atomic<bool> cancel(false);


### PR DESCRIPTION
# Description 
This PR adds Mathematica package `SparseRREF.wl` with a convenient Mathematica API.

The package has one public function: `SparseRREF[mat_SparseArray, opts : OptionsPattern[]]`.
This function computes RREF of a rational matrix or an integer matrix modulo `p` (if `Modulus -> p` is specified).
Internally, it calls either `rational_rref()` or `modrref()` from `mma_link.cpp`.

The package should be in the same directory as `mathlink.dll` (compiled from `mma_link.cpp`).

Tested via wolframscript on Mathematica 12.3 and Mathematica 14.3 on Linux.

## `SparseRREF[]` options
Mathematica API allows to set the same options as SparseRREF executable (but with different names).
For convenience, I've added string aliases to `OutputMode` and `Method` values.
- `Modulus -> 0` ([standard option](http://reference.wolfram.com/language/ref/Modulus.html) for built-in Mathematica functions):
  `0`: compute RREF over rational field.
  prime number `p`: compute RREF over finite field `Z/p` (integers modulo `p`).
- `"OutputMode" -> "RREF"` - return value:
  - `0`, `"RREF"`: rref
  -  `1`, `"RREF,Kernel"`: `{rref, kernel}`
  - `2`, `"RREF,Pivots"`: `{rref, pivots}` (only for `Modulus -> 0`)
  - `3`, `"RREF,Kernel,Pivots"`: `{rref, kernel, pivots}` (only for `Modulus -> 0`)
- `"Method" -> "RightAndLeft"`:
  - `0`, `"RightAndLeft"`: right and left search
  - `1`, `"Right"`: only right search (chooses the leftmost independent columns as pivots)
  - `2`, `"Hybrid"`: hybrid
- `"BackwardSubstitution" -> True`:
  - `True`: the submatrix $\Lambda[\text{rows in pivots},\text{cols in pivots}]$ of RREF $\Lambda$ is an identity matrix.
  - `False`: the submatrix is upper triangular.
- `"Threads" -> 1`: number of threads (nonnegative integer).
- `"Verbose" -> False`: print steps if `True`.
- `"PrintStep" -> 100` (Integer): print each i-th step if `"Verbose" -> True`.
  
## Validation and error handling
- `SparseRREF::findlib` message is printed if `mathlink.dll` (or `.so`, or `.dylib`) library is not found
- `SparseRREF::optionvalue` message is printed if invalid value is passed, e.g. `"Threads" -> "foo"`.
- `SparseRREF::rettype` message is printed if C++ function returns result of a wrong type (not `SparseArray` or `List`)

In any of those cases, `SparseRREF` returns `$Failed`.

## Documentation
- Comments in the beginning of `SparseRREF.wl` describe how to use the package.
- `Readme.md` contains `Mathematica API` section.
- Updated comments at the top of `mma_link.cpp`.

## Example 
```mathematica
Needs["SparseRREF`"];
(* or: Needs["SparseRREF`", "/path/to/SparseRREF.wl"]; *)

(* Rationals *)
mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
rref = SparseRREF[mat];
{rref, kernel, pivots} = SparseRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "BackwardSubstitution" -> True, "Threads" -> $ProcessorCount, "Verbose" -> True, "PrintStep" -> 10];

(* Integers mod p *)
mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
p = 7;
{rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];

```

# Breaking changes

Functions `rational_rref` and `modrref` get extra arguments for `Method`, `BackwardSubstitution`, `Verbose` and `PrintStep`.

# TODO

This PR can be merged "as is", but there are a few more things to consider (maybe in future PRs):

1. I'm not quite happy with file names. Currently, we have the source file `mma_link.cpp` and the library `mathlink.dll`. The names are different and `mathlink` is not specific enough in case you install it to some common folder like `/usr/lib`. I'd suggest e.g. something like `SparseRREF_WolframLibraryLink.dll` + `WolframLibraryLink.cpp`, or `SparseRREF_mma_link.dll` + `mma_link.cpp`.
2. `modrref` does not support `"OutputMode" -> "RREF,Pivots"` and `"OutputMode" -> "RREF,Kernel,Pivots"`.
3. Ideally, it would be nice to replace `rational_rref()` and `modrref()` with a single function. Currently, `rational_rref()` accepts serialized `SparseArray` and returns either serialized `SparseArray` or serialized `List` of `SparseArray`'s. `modrref()` accepts `SparseArray` and returns `SparseArray` (which should be split into rref and kernel on Mathematica side).
`rational_rref()` design looks more flexible. Are there any downsides (e.g. slowdown due to extra serialization) to rewriting `modrref()` in the same way?
4. `mma_link.cpp` also exports functions `modpmatmul` and `ratmat_inv`. I haven't added them to `SparseRREF.wl`.