### PR TITLE
Add Mathematica byte-identical WXF output

### DIFF
--- a/wxf_parser.h
+++ b/wxf_parser.h
@@ -51,6 +51,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 
 namespace WXF_PARSER {
 
@@ -301,8 +302,59 @@ namespace WXF_PARSER {
 			return all_len;
 		}
 
-		template<typename T>
-		Encoder& push_array(const std::vector<size_t>& dimension_array, const std::span<T> data, WXF_HEAD type, uint8_t num_type) {
+		template<typename T, typename F = std::identity>
+			requires std::is_invocable_v<F&, const T&>
+		Encoder& push_array_data(const std::span<T> data, uint8_t num_type, F&& func = std::identity{}) {
+			// backup current size
+			size_t old_size = buffer.size();
+			using value_t = std::remove_cvref_t<std::invoke_result_t<F&, const T&>>;
+			
+			if constexpr (std::is_integral_v<value_t>) {
+				const bool consistent_sign = (num_type >> 2) == (std::is_unsigned_v<value_t> ? (16 >> 2) : 0);
+				if (size_of_arr_num_type(num_type) == sizeof(value_t) && consistent_sign) {
+					if constexpr (std::is_same_v<std::remove_cvref_t<F>, std::identity>) {
+						return push_ustr(data.data(), data.size());
+					}
+					else {
+						return transform_back_ustr<value_t>(data.data(), data.size(), func);
+					}
+				}
+
+#define APPEND_CASTED_ARRAY_DATA(TYPE) do {                                            \
+				transform_back_ustr<TYPE>(data.data(), data.size(),                    \
+					[&](const T& value) { return static_cast<TYPE>(func(value)); });   \
+				} while (0)
+
+				switch (num_type) {
+				case 0: APPEND_CASTED_ARRAY_DATA(int8_t); break;
+				case 1: APPEND_CASTED_ARRAY_DATA(int16_t); break;
+				case 2: APPEND_CASTED_ARRAY_DATA(int32_t); break;
+				case 3: APPEND_CASTED_ARRAY_DATA(int64_t); break;
+				case 16: APPEND_CASTED_ARRAY_DATA(uint8_t); break;
+				case 17: APPEND_CASTED_ARRAY_DATA(uint16_t); break;
+				case 18: APPEND_CASTED_ARRAY_DATA(uint32_t); break;
+				case 19: APPEND_CASTED_ARRAY_DATA(uint64_t); break;
+				default: std::cerr << "Encoder::push_array_data: unsupported integer array num_type "
+						<< static_cast<int>(num_type) << "." << std::endl;
+					buffer.resize(old_size);
+					break;
+				}
+				return *this;
+#undef APPEND_CASTED_ARRAY_DATA
+			}
+			else {
+				if constexpr (std::is_same_v<std::remove_cvref_t<F>, std::identity>) {
+					return push_ustr(data.data(), data.size());
+				}
+				else {
+					return transform_back_ustr<value_t>(data.data(), data.size(), func);
+				}
+			}
+		}
+
+		template<typename T, typename F = std::identity>
+			requires std::is_invocable_v<F&, const T&>
+		Encoder& push_array(const std::vector<size_t>& dimension_array, const std::span<T> data, WXF_HEAD type, uint8_t num_type, F&& func = std::identity{}) {
 			// backup current size
 			size_t old_size = buffer.size();
 
@@ -317,7 +369,74 @@ namespace WXF_PARSER {
 			}
 
 			// push data
-			return push_ustr(data.data(), data.size());
+			if constexpr (std::is_integral_v<T>) {
+				const bool supported_num_type = num_type <= 3 || (num_type >= 16 && num_type <= 19);
+				if (!supported_num_type) {
+					std::cerr << "Encoder::push_array: unsupported integer array num_type "
+						<< static_cast<int>(num_type) << "." << std::endl;
+					buffer.resize(old_size);
+					return *this;
+				}
+			}
+			return push_array_data(data, num_type, std::forward<F>(func));
+		}
+
+		template<typename F>
+			requires std::is_invocable_v<F&, size_t>
+		Encoder& push_generated_array_data(const size_t len, uint8_t num_type, F&& func) {
+			// backup current size
+			size_t old_size = buffer.size();
+			using value_t = std::remove_cvref_t<std::invoke_result_t<F&, size_t>>;
+
+			if constexpr (std::is_integral_v<value_t>) {
+#define GENERATE_ARRAY_DATA(TYPE) do {                               \
+				generate_back_ustr<TYPE>(len, [&](size_t i) {        \
+					return static_cast<TYPE>(func(i));               \
+				});} while (0)
+
+				switch (num_type) {
+				case 0: GENERATE_ARRAY_DATA(int8_t); break;
+				case 1: GENERATE_ARRAY_DATA(int16_t); break;
+				case 2: GENERATE_ARRAY_DATA(int32_t); break;
+				case 3: GENERATE_ARRAY_DATA(int64_t); break;
+				case 16: GENERATE_ARRAY_DATA(uint8_t); break;
+				case 17: GENERATE_ARRAY_DATA(uint16_t); break;
+				case 18: GENERATE_ARRAY_DATA(uint32_t); break;
+				case 19: GENERATE_ARRAY_DATA(uint64_t); break;
+				default: std::cerr << "Encoder::push_generated_array_data: unsupported integer array num_type "
+						<< static_cast<int>(num_type) << "." << std::endl;
+					buffer.resize(old_size);
+					break;
+				}
+				return *this;
+#undef GENERATE_ARRAY_DATA
+			}
+			else {
+				return generate_back_ustr<value_t>(len, func);
+			}
+		}
+
+		template<typename F>
+			requires std::is_invocable_v<F&, size_t>
+		Encoder& push_generated_array(const std::vector<size_t>& dimension_array, WXF_HEAD type, uint8_t num_type, F&& func) {
+			// backup current size
+			size_t old_size = buffer.size();
+			using value_t = std::remove_cvref_t<std::invoke_result_t<F&, size_t>>;
+
+			// [array_type, num_type, rank, dimensions..., data...]
+			auto all_len = push_array_info(dimension_array, type, num_type);
+
+			// push data
+			if constexpr (std::is_integral_v<value_t>) {
+				const bool supported_num_type = num_type <= 3 || (num_type >= 16 && num_type <= 19);
+				if (!supported_num_type) {
+					std::cerr << "Encoder::push_generated_array: unsupported integer array num_type "
+						<< static_cast<int>(num_type) << "." << std::endl;
+					buffer.resize(old_size);
+					return *this;
+				}
+			}
+			return push_generated_array_data(all_len, num_type, std::forward<F>(func));
 		}
 
 		template<typename T>

--- a/wxf_parser.h
+++ b/wxf_parser.h
@@ -49,6 +49,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 
 namespace WXF_PARSER {
@@ -179,6 +180,11 @@ namespace WXF_PARSER {
 		// move from existing buffer
 		Encoder(std::vector<uint8_t>&& buf) : buffer(std::move(buf)) {}
 
+		const size_t size() const { return buffer.size(); }
+		void reserve(const size_t new_size) { buffer.reserve(new_size); }
+		void resize(const size_t new_size) { buffer.resize(new_size); }
+		void resize(const size_t new_size, const uint8_t val) { buffer.resize(new_size, val); }
+
 		// push ustr directly
 		Encoder& push_ustr(const std::vector<uint8_t>& str) { buffer.insert(buffer.end(), str.begin(), str.end()); return *this; }
 		Encoder& push_ustr(const std::string_view str) {
@@ -191,6 +197,36 @@ namespace WXF_PARSER {
 		template<typename T>
 		Encoder& push_ustr(T* start, T* end) {
 			buffer.insert(buffer.end(), (uint8_t*)start, (uint8_t*)end); return *this;
+		}
+
+		// generate data as ustr in the back
+		template<typename T, typename F>
+		Encoder& generate_back_ustr(const size_t len, F&& func) {
+			static_assert(std::is_trivially_copyable_v<T>, "T should be trivially copyable");
+			static_assert(std::is_invocable_r_v<T, F&, size_t>, "func should be callable with size_t and return T");
+			size_t old_size = buffer.size();
+			buffer.resize(old_size + len * sizeof(T));
+			uint8_t* data_ptr = buffer.data() + old_size;
+			for (size_t i = 0; i < len; i++) {
+				T value = func(i);
+				std::memcpy(data_ptr + i * sizeof(T), &value, sizeof(T));
+			}
+			return *this;
+		}
+
+		// generate transformed data as ustr in the back
+		template<typename T1, typename T2, typename F>
+		Encoder& transform_back_ustr(const T2* src_ptr, const size_t len, F&& func) {
+			static_assert(std::is_trivially_copyable_v<T1>, "T1 should be trivially copyable");
+			static_assert(std::is_invocable_r_v<T1, F&, const T2&>, "func should be callable with T2 and return T1");
+			size_t old_size = buffer.size();
+			buffer.resize(old_size + len * sizeof(T1));
+			uint8_t* data_ptr = buffer.data() + old_size;
+			for (size_t i = 0; i < len; i++) {
+				T1 value = func(src_ptr[i]);
+				std::memcpy(data_ptr + i * sizeof(T1), &value, sizeof(T1));
+			}
+			return *this;
 		}
 
 		Encoder& push_integer(const int64_t val) {
@@ -1242,9 +1278,8 @@ namespace WXF_PARSER::FullForm {
 
 namespace WXF_PARSER {
 	// we allow use a map to store function that generating sub-expressions
-	template<typename Callable>
-	void fullform_to_wxf(Encoder& encoder, const FullForm::expression& expr,
-		const std::unordered_map<std::string, Callable>& map) {
+	inline void fullform_to_wxf(Encoder& encoder, const FullForm::expression& expr,
+		const std::unordered_map<std::string, std::function<void(Encoder&)>>& map) {
 
 		if (expr.is_atom()) {
 			switch (expr.head_.get_type()) {

--- a/wxf_support.h
+++ b/wxf_support.h
@@ -9,11 +9,73 @@
 #ifndef WXF_SUPPORT_H
 #define WXF_SUPPORT_H
 
+#include <algorithm>
+#include <limits>
+#include <type_traits>
+
 #include "wxf_parser.h"
 #include "sparse_type.h"
 
 namespace SparseRREF {
 	// TODO: reuse the code for sparse_mat_read_wxf and sparse_tensor_read_wxf
+
+	namespace WXF_HELPER {
+		// value fits in int64_t as an integer
+		inline bool value_fits_si(const rat_t& value) { return value.is_integer() && value.num().fits_si(); }
+		inline bool value_fits_si(const int_t& value) { return value.fits_si(); }
+		inline bool value_fits_si(ulong value) { return value <= static_cast<ulong>(INT64_MAX); }
+
+		// value to int64_t (unchecked!!)
+		inline int64_t value_to_si(const rat_t& value) { return static_cast<int64_t>(value.num().to_si()); }
+		inline int64_t value_to_si(const int_t& value) { return static_cast<int64_t>(value.to_si()); }
+		inline int64_t value_to_si(ulong value) { return static_cast<int64_t>(value); }
+
+		template <typename T>
+			requires std::is_same_v<T, int_t> || std::is_same_v<T, ulong>
+		inline void push_value(WXF_PARSER::Encoder& enc, const T& value) {
+			if (value_fits_si(value))
+				enc.push_integer(value_to_si(value));
+			else
+				enc.push_bigint(scalar_to_str(value));
+		}
+
+		template <typename T>
+			requires std::is_same_v<T, rat_t>
+		inline void push_value(WXF_PARSER::Encoder& enc, const T& value) {
+			if (value.is_integer()) {
+				push_value(enc, value.num());
+			}
+			else {
+				// func,2,symbol,8,"Rational"
+				enc.push_ustr("f\x02s\x08Rational");
+				push_value(enc, value.num());
+				push_value(enc, value.den());
+			}
+		}
+
+		template <typename T>
+			requires std::is_same_v<T, ulong> || std::is_same_v<T, int_t> || std::is_same_v<T, rat_t>
+		inline uint8_t vals_array_num_type(const std::span<T> vals) {
+			if (vals.empty())
+				return 0;
+			if (!value_fits_si(vals[0]))
+				return 102;
+			int64_t min_val = value_to_si(vals[0]);
+			int64_t max_val = min_val;
+			for (size_t i = 1; i < vals.size(); i++) {
+				if (!value_fits_si(vals[i]))
+					return 102;
+				auto value = value_to_si(vals[i]);
+				if (value < min_val)
+					min_val = value;
+				if (value > max_val)
+					max_val = value;
+			}
+			auto min_type = WXF_PARSER::minimal_signed_bits(min_val);
+			auto max_type = WXF_PARSER::minimal_signed_bits(max_val);
+			return std::max(min_type, max_type);
+		}
+	}
 
 	template <typename T, typename index_t>
 	sparse_mat<T, index_t> sparse_mat_read_wxf(const std::vector<WXF_PARSER::Token>& tokens, const field_t& F) {
@@ -310,7 +372,7 @@ namespace SparseRREF {
 			case 1: APPEND_COLIND_DATA(int16_t); break;
 			case 2: APPEND_COLIND_DATA(int32_t); break;
 			case 3: APPEND_COLIND_DATA(int64_t); break;
-			case 4: std::cerr << "Error: sparse_tensor_write_wxf: too large dimension" << std::endl; break;
+			case 4: std::cerr << "Error: sparse_mat_write_wxf: too large dimension" << std::endl; break;
 			}
 #undef APPEND_COLIND_DATA
 			};
@@ -351,6 +413,102 @@ namespace SparseRREF {
 				for (size_t i = 0; i < mat.nrow; i++) {
 					enc.push_ustr(mat[i].entries, mat[i].nnz());
 				}
+			}
+			};
+
+		Encoder enc = fullform_to_wxf(ff_template, func_map, include_head);
+
+		return enc.buffer;
+	}
+
+	template <typename T, typename index_t>
+	std::vector<uint8_t> sparse_mat_write_mma_wxf(const sparse_mat<T, index_t>& mat, bool include_head = true) {
+		using namespace WXF_PARSER;
+
+		if (mat.nrow == 0)
+			return std::vector<uint8_t>();
+
+		std::string_view ff_template = "SparseArray[Automatic,#dims,0,{1,{#rowptr,#colindex},#vals}]";
+
+		size_t rank = 2;
+		size_t nnz = mat.nnz();
+		std::vector<size_t> dims_arr = { mat.nrow, mat.ncol };
+
+		std::unordered_map<std::string, std::function<void(Encoder&)>> func_map;
+
+		func_map["#dims"] = [&](Encoder& enc) {
+			auto num_type = WXF_PARSER::minimal_pos_signed_bits(*std::max_element(dims_arr.begin(), dims_arr.end()));
+			enc.push_array({ 2 }, std::span(dims_arr), WXF_HEAD::array, num_type);
+			};
+
+		func_map["#rowptr"] = [&](Encoder& enc) {
+			auto num_type = WXF_PARSER::minimal_pos_signed_bits(nnz);
+			std::vector<size_t> rowptr(mat.nrow + 1);
+			rowptr[0] = 0;
+			for (size_t i = 0; i < mat.nrow; i++)
+				rowptr[i + 1] = rowptr[i] + mat[i].nnz();
+			enc.push_array({ mat.nrow + 1 }, std::span(rowptr), WXF_HEAD::array, num_type);
+			};
+
+		func_map["#colindex"] = [&](Encoder& enc) {
+			size_t max_colindex = 0;
+			for (size_t i = 0; i < mat.nrow; i++) {
+				auto index_span = mat[i].index_span();
+				if (!index_span.empty()) {
+					auto colindex = static_cast<size_t>(*std::max_element(index_span.begin(), index_span.end())) + 1;
+					if (colindex > max_colindex)
+						max_colindex = colindex;
+				}
+			}
+			auto num_type = WXF_PARSER::minimal_pos_signed_bits(max_colindex);
+			if (num_type > 3) {
+				std::cerr << "Error: sparse_mat_write_mma_wxf: too large dimension" << std::endl;
+				return;
+			}
+			enc.push_array_info({ nnz, rank - 1 }, WXF_HEAD::array, num_type);
+			enc.buffer.reserve(enc.buffer.size() + nnz * (rank - 1) * WXF_PARSER::size_of_arr_num_type(num_type));
+			for (size_t i = 0; i < mat.nrow; i++) {
+				if (mat[i].nnz() != 0)
+					enc.push_array_data(mat[i].index_span(), num_type, [](const index_t& idx) {
+						return idx + 1; // assumes idx + 1 does not exceed std::numeric_limits<index_t>::max()
+						});
+			}
+			};
+
+		func_map["#vals"] = [&](Encoder& enc) {
+			if constexpr (std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>) {
+				uint8_t num_type = 0;
+				for (size_t i = 0; i < mat.nrow; i++) {
+					auto row_num_type = WXF_HELPER::vals_array_num_type(mat[i].entry_span());
+					if (row_num_type == 102) {
+						num_type = 102;
+						break;
+					}
+					num_type = std::max(num_type, row_num_type);
+				}
+
+				if (num_type != 102) {
+					enc.push_array_info({ nnz }, WXF_HEAD::array, num_type);
+					enc.buffer.reserve(enc.buffer.size() + nnz * WXF_PARSER::size_of_arr_num_type(num_type));
+					for (size_t i = 0; i < mat.nrow; i++) {
+						if (mat[i].nnz() != 0)
+							enc.push_array_data(mat[i].entry_span(), num_type, [](const T& value) {
+								return WXF_HELPER::value_to_si(value);
+								});
+					}
+				}
+				else {
+					enc.push_function("List", nnz);
+					for (size_t i = 0; i < mat.nrow; i++) {
+						for (size_t j = 0; j < mat[i].nnz(); j++) {
+							WXF_HELPER::push_value(enc, mat[i][j]);
+						}
+					}
+				}
+			}
+			else {
+				static_assert(std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>,
+					"Unsupported SparseRREF WXF value type.");
 			}
 			};
 
@@ -713,6 +871,71 @@ namespace SparseRREF {
 			else if constexpr (std::is_same_v<T, ulong>) {
 				enc.push_array_info({ nnz }, WXF_HEAD::narray, 19);
 				enc.push_ustr(tensor.data.valptr, tensor.data.valptr + nnz);
+			}
+			};
+
+		Encoder enc = fullform_to_wxf(ff_template, func_map, include_head);
+
+		return enc.buffer;
+	}
+
+	template <typename T, typename index_t>
+	std::vector<uint8_t> sparse_tensor_write_mma_wxf(const sparse_tensor<T, index_t, SPARSE_CSR>& tensor, bool include_head = true) {
+		using namespace WXF_PARSER;
+
+		if (tensor.alloc() == 0)
+			return std::vector<uint8_t>();
+
+		std::string_view ff_template = "SparseArray[Automatic,#dims,0,{1,{#rowptr,#colindex},#vals}]";
+
+		auto rank = tensor.rank();
+		auto nnz = tensor.nnz();
+		std::vector<size_t> dims(tensor.dims().begin(), tensor.dims().end());
+
+		std::unordered_map<std::string, std::function<void(Encoder&)>> func_map;
+
+		func_map["#dims"] = [&](Encoder& enc) {
+			auto num_type = WXF_PARSER::minimal_pos_signed_bits(*std::max_element(dims.begin(), dims.end()));
+			enc.push_array({ rank }, std::span(dims), WXF_HEAD::array, num_type);
+			};
+
+		func_map["#rowptr"] = [&](Encoder& enc) {
+			const auto& rowptr = tensor.data.rowptr;
+			auto num_type = WXF_PARSER::minimal_pos_signed_bits(nnz);
+			enc.push_array({ rowptr.size() }, std::span(rowptr), WXF_HEAD::array, num_type);
+			};
+
+
+		func_map["#colindex"] = [&](Encoder& enc) {
+			auto col_span = std::span(tensor.data.colptr, (rank - 1) * nnz);
+			size_t max_colindex = 0;
+			if (!col_span.empty())
+				max_colindex = static_cast<size_t>(*std::max_element(col_span.begin(), col_span.end())) + 1;
+			auto num_type = WXF_PARSER::minimal_pos_signed_bits(max_colindex);
+			enc.push_array({ nnz, rank - 1 }, col_span, WXF_HEAD::array, num_type, [](const index_t& idx) {
+				return idx + 1; // assumes idx + 1 does not exceed std::numeric_limits<index_t>::max()
+				});
+			};
+
+		func_map["#vals"] = [&](Encoder& enc) {
+			if constexpr (std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>) {
+				auto val_span = std::span(tensor.data.valptr, nnz);
+				auto num_type = WXF_HELPER::vals_array_num_type(val_span);
+				if (num_type != 102) {
+					enc.push_array({ nnz }, val_span, WXF_HEAD::array, num_type, [](const T& value) {
+						return WXF_HELPER::value_to_si(value);
+						});
+				}
+				else {
+					enc.push_function("List", nnz);
+					for (size_t i = 0; i < nnz; i++) {
+						WXF_HELPER::push_value(enc, tensor.val(i));
+					}
+				}
+			}
+			else {
+				static_assert(std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>,
+					"Unsupported SparseRREF WXF value type.");
 			}
 			};
 

--- a/wxf_support.h
+++ b/wxf_support.h
@@ -324,105 +324,7 @@ namespace SparseRREF {
 
 	// SparseArray[Automatic,dims,imp_val = 0,{1,{rowptr,colindex},vals}]
 	template <typename T, typename index_t>
-	std::vector<uint8_t> sparse_mat_write_wxf(const sparse_mat<T, index_t>& mat, bool include_head = true) {
-		using namespace WXF_PARSER;
-
-		if (mat.nrow == 0)
-			return std::vector<uint8_t>();
-
-		std::string_view ff_template = "SparseArray[Automatic,#dims,0,{1,{#rowptr,#colindex},#vals}]";
-
-		size_t rank = 2;
-		size_t nnz = mat.nnz();
-		std::vector<int64_t> dims_arr = { (int64_t)mat.nrow, (int64_t)mat.ncol };
-
-		std::unordered_map<std::string, std::function<void(Encoder&)>> func_map;
-
-		func_map["#dims"] = [&](Encoder& enc) {
-			enc.push_packed_array({ 2 }, dims_arr);
-			};
-
-		func_map["#rowptr"] = [&](Encoder& enc) {
-			std::vector<int64_t> rowptr(mat.nrow + 1);
-			rowptr[0] = 0;
-			for (size_t i = 0; i < mat.nrow; i++) {
-				rowptr[i + 1] = rowptr[i] + mat[i].nnz();
-			}
-			enc.push_packed_array({ mat.nrow + 1 }, rowptr);
-			};
-
-		func_map["#colindex"] = [&](Encoder& enc) {
-			auto mz = minimal_pos_signed_bits(mat.ncol);
-			enc.push_array_info({ nnz, rank - 1 }, WXF_HEAD::array, mz);
-
-#define APPEND_COLIND_DATA(TYPE) do {                                   \
-		std::vector<TYPE> tmp((rank - 1) * nnz);                        \
-		size_t idx = 0;                                                 \
-		for (size_t i = 0; i < mat.nrow; i++) {                         \
-			for (size_t j = 0; j < mat[i].nnz(); j++) {                 \
-				tmp[idx] = mat[i](j) + 1;                               \
-				idx++;                                                  \
-			}                                                           \
-		}                                                               \
-		enc.push_ustr(tmp.data(), tmp.size());                          \
-	} while (0)
-
-			switch (mz) {
-			case 0: APPEND_COLIND_DATA(int8_t); break;
-			case 1: APPEND_COLIND_DATA(int16_t); break;
-			case 2: APPEND_COLIND_DATA(int32_t); break;
-			case 3: APPEND_COLIND_DATA(int64_t); break;
-			case 4: std::cerr << "Error: sparse_mat_write_wxf: too large dimension" << std::endl; break;
-			}
-#undef APPEND_COLIND_DATA
-			};
-
-		func_map["#vals"] = [&](Encoder& enc) {
-			auto push_int = [&](const int_t& val) {
-				if (val.fits_si())
-					enc.push_integer(val.to_si());
-				else
-					enc.push_bigint(val.get_str());
-				};
-
-			if constexpr (std::is_same_v<T, rat_t>) {
-				enc.push_function("List", nnz);
-				for (size_t i = 0; i < mat.nrow; i++) {
-					for (size_t j = 0; j < mat[i].nnz(); j++) {
-						auto& rat_val = mat[i][j];
-						if (rat_val.is_integer())
-							push_int(rat_val.num());
-						else {
-							// func,2,symbol,8,"Rational"
-							enc.push_ustr("f\x02s\x08Rational");
-							push_int(rat_val.num());
-							push_int(rat_val.den());
-						}
-					}
-				}
-			}
-			else if constexpr (std::is_same_v<T, int_t>) {
-				enc.push_function("List", nnz);
-				for (size_t i = 0; i < mat.nrow; i++) {
-					for (size_t j = 0; j < mat[i].nnz(); j++)
-						push_int(mat[i][j]);
-				}
-			}
-			else if constexpr (std::is_same_v<T, ulong>) {
-				enc.push_array_info({ nnz }, WXF_HEAD::narray, 19);
-				for (size_t i = 0; i < mat.nrow; i++) {
-					enc.push_ustr(mat[i].entries, mat[i].nnz());
-				}
-			}
-			};
-
-		Encoder enc = fullform_to_wxf(ff_template, func_map, include_head);
-
-		return enc.buffer;
-	}
-
-	template <typename T, typename index_t>
-	std::vector<uint8_t> sparse_mat_write_mma_wxf(const sparse_mat<T, index_t>& mat, bool include_head = true) {
+	std::vector<uint8_t> sparse_mat_write_wxf(const sparse_mat<T, index_t>& mat, bool include_head = true, bool mma_layout = false) {
 		using namespace WXF_PARSER;
 
 		if (mat.nrow == 0)
@@ -437,35 +339,57 @@ namespace SparseRREF {
 		std::unordered_map<std::string, std::function<void(Encoder&)>> func_map;
 
 		func_map["#dims"] = [&](Encoder& enc) {
-			auto num_type = WXF_PARSER::minimal_pos_signed_bits(*std::max_element(dims_arr.begin(), dims_arr.end()));
-			enc.push_array({ 2 }, std::span(dims_arr), WXF_HEAD::array, num_type);
+			if (mma_layout) {
+				auto num_type = WXF_PARSER::minimal_pos_signed_bits(*std::max_element(dims_arr.begin(), dims_arr.end()));
+				enc.push_array({ 2 }, std::span(dims_arr), WXF_HEAD::array, num_type);
+			}
+			else {
+				std::vector<int64_t> dims_arr_legacy = { (int64_t)mat.nrow, (int64_t)mat.ncol };
+				enc.push_packed_array({ 2 }, dims_arr_legacy);
+			}
 			};
 
 		func_map["#rowptr"] = [&](Encoder& enc) {
-			auto num_type = WXF_PARSER::minimal_pos_signed_bits(nnz);
-			std::vector<size_t> rowptr(mat.nrow + 1);
-			rowptr[0] = 0;
-			for (size_t i = 0; i < mat.nrow; i++)
-				rowptr[i + 1] = rowptr[i] + mat[i].nnz();
-			enc.push_array({ mat.nrow + 1 }, std::span(rowptr), WXF_HEAD::array, num_type);
+			if (mma_layout) {
+				auto num_type = WXF_PARSER::minimal_pos_signed_bits(nnz);
+				std::vector<size_t> rowptr(mat.nrow + 1);
+				rowptr[0] = 0;
+				for (size_t i = 0; i < mat.nrow; i++)
+					rowptr[i + 1] = rowptr[i] + mat[i].nnz();
+				enc.push_array({ mat.nrow + 1 }, std::span(rowptr), WXF_HEAD::array, num_type);
+			}
+			else {
+				std::vector<int64_t> rowptr(mat.nrow + 1);
+				rowptr[0] = 0;
+				for (size_t i = 0; i < mat.nrow; i++) {
+					rowptr[i + 1] = rowptr[i] + mat[i].nnz();
+				}
+				enc.push_packed_array({ mat.nrow + 1 }, rowptr);
+			}
 			};
 
 		func_map["#colindex"] = [&](Encoder& enc) {
-			size_t max_colindex = 0;
-			for (size_t i = 0; i < mat.nrow; i++) {
-				auto index_span = mat[i].index_span();
-				if (!index_span.empty()) {
-					auto colindex = static_cast<size_t>(*std::max_element(index_span.begin(), index_span.end())) + 1;
-					if (colindex > max_colindex)
-						max_colindex = colindex;
+			uint8_t num_type = 0;
+			if (mma_layout) {
+				size_t max_colindex = 0;
+				for (size_t i = 0; i < mat.nrow; i++) {
+					auto index_span = mat[i].index_span();
+					if (!index_span.empty()) {
+						auto colindex = static_cast<size_t>(*std::max_element(index_span.begin(), index_span.end())) + 1;
+						if (colindex > max_colindex)
+							max_colindex = colindex;
+					}
 				}
+				num_type = WXF_PARSER::minimal_pos_signed_bits(max_colindex);
 			}
-			auto num_type = WXF_PARSER::minimal_pos_signed_bits(max_colindex);
-			if (num_type > 3) {
-				std::cerr << "Error: sparse_mat_write_mma_wxf: too large dimension" << std::endl;
-				return;
+			else {
+				num_type = minimal_pos_signed_bits(mat.ncol);
 			}
 			enc.push_array_info({ nnz, rank - 1 }, WXF_HEAD::array, num_type);
+			if (num_type > 3) {
+				std::cerr << "Error: sparse_mat_write_wxf: too large dimension" << std::endl;
+				return;
+			}
 			enc.buffer.reserve(enc.buffer.size() + nnz * (rank - 1) * WXF_PARSER::size_of_arr_num_type(num_type));
 			for (size_t i = 0; i < mat.nrow; i++) {
 				if (mat[i].nnz() != 0)
@@ -477,38 +401,49 @@ namespace SparseRREF {
 
 		func_map["#vals"] = [&](Encoder& enc) {
 			if constexpr (std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>) {
-				uint8_t num_type = 0;
-				for (size_t i = 0; i < mat.nrow; i++) {
-					auto row_num_type = WXF_HELPER::vals_array_num_type(mat[i].entry_span());
-					if (row_num_type == 102) {
-						num_type = 102;
-						break;
-					}
-					num_type = std::max(num_type, row_num_type);
-				}
-
-				if (num_type != 102) {
-					enc.push_array_info({ nnz }, WXF_HEAD::array, num_type);
-					enc.buffer.reserve(enc.buffer.size() + nnz * WXF_PARSER::size_of_arr_num_type(num_type));
+				if (mma_layout) {
+					uint8_t num_type = 0;
 					for (size_t i = 0; i < mat.nrow; i++) {
-						if (mat[i].nnz() != 0)
-							enc.push_array_data(mat[i].entry_span(), num_type, [](const T& value) {
-								return WXF_HELPER::value_to_si(value);
-								});
+						auto row_num_type = WXF_HELPER::vals_array_num_type(mat[i].entry_span());
+						if (row_num_type == 102) {
+							num_type = 102;
+							break;
+						}
+						num_type = std::max(num_type, row_num_type);
+					}
+
+					if (num_type != 102) {
+						enc.push_array_info({ nnz }, WXF_HEAD::array, num_type);
+						enc.buffer.reserve(enc.buffer.size() + nnz * WXF_PARSER::size_of_arr_num_type(num_type));
+						for (size_t i = 0; i < mat.nrow; i++) {
+							if (mat[i].nnz() != 0)
+								enc.push_array_data(mat[i].entry_span(), num_type, [](const T& value) {
+									return WXF_HELPER::value_to_si(value);
+									});
+						}
+					}
+					else {
+						enc.push_function("List", nnz);
+						for (size_t i = 0; i < mat.nrow; i++) {
+							for (size_t j = 0; j < mat[i].nnz(); j++) {
+								WXF_HELPER::push_value(enc, mat[i][j]);
+							}
+						}
+					}
+				}
+				else if constexpr (std::is_same_v<T, ulong>) {
+					enc.push_array_info({ nnz }, WXF_HEAD::narray, 19);
+					for (size_t i = 0; i < mat.nrow; i++) {
+						enc.push_ustr(mat[i].entries, mat[i].nnz());
 					}
 				}
 				else {
 					enc.push_function("List", nnz);
 					for (size_t i = 0; i < mat.nrow; i++) {
-						for (size_t j = 0; j < mat[i].nnz(); j++) {
+						for (size_t j = 0; j < mat[i].nnz(); j++)
 							WXF_HELPER::push_value(enc, mat[i][j]);
-						}
 					}
 				}
-			}
-			else {
-				static_assert(std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>,
-					"Unsupported SparseRREF WXF value type.");
 			}
 			};
 
@@ -793,94 +728,7 @@ namespace SparseRREF {
 
 	// SparseArray[Automatic,dims,imp_val = 0,{1,{rowptr,colindex},vals}]
 	template <typename T, typename index_t>
-	std::vector<uint8_t> sparse_tensor_write_wxf(const sparse_tensor<T, index_t, SPARSE_CSR>& tensor, bool include_head = true) {
-		using namespace WXF_PARSER;
-
-		if (tensor.alloc() == 0)
-			return std::vector<uint8_t>();
-
-		std::string_view ff_template = "SparseArray[Automatic,#dims,0,{1,{#rowptr,#colindex},#vals}]";
-
-		auto rank = tensor.rank();
-		auto nnz = tensor.nnz();
-		std::vector<int64_t> dims(tensor.dims().begin(), tensor.dims().end());
-
-		std::unordered_map<std::string, std::function<void(Encoder&)>> func_map;
-
-		func_map["#dims"] = [&](Encoder& enc) {
-			enc.push_packed_array({ rank }, dims);
-			};
-
-		// important: we assume size_t fits into int64_t !!!!!!!!!
-		func_map["#rowptr"] = [&](Encoder& enc) {
-			const auto& rowptr = tensor.data.rowptr;
-			enc.push_array_info({ rowptr.size() }, WXF_HEAD::array, 3);
-			enc.push_ustr(rowptr.data(), rowptr.size());
-			};
-
-
-		func_map["#colindex"] = [&](Encoder& enc) {
-			auto mz = minimal_pos_signed_bits(1 + *std::max_element(dims.begin() + 1, dims.end()));
-			enc.push_array_info({ nnz, rank - 1 }, WXF_HEAD::array, mz);
-
-#define APPEND_COLIND_DATA(TYPE) do {                                   \
-        std::vector<TYPE> tmp((rank - 1) * nnz);                        \
-        for (size_t i = 0; i < tmp.size(); i++)                         \
-            tmp[i] = tensor.data.colptr[i] + 1;                         \
-		enc.push_ustr(tmp.data(), tmp.size());                          \
-    } while (0)
-
-			switch (mz) {
-			case 0: APPEND_COLIND_DATA(int8_t); break;
-			case 1: APPEND_COLIND_DATA(int16_t); break;
-			case 2: APPEND_COLIND_DATA(int32_t); break;
-			case 3: APPEND_COLIND_DATA(int64_t); break;
-			case 4: std::cerr << "Error: sparse_tensor_write_wxf: too large dimension" << std::endl; break;
-			}
-#undef APPEND_COLIND_DATA
-			};
-
-		func_map["#vals"] = [&](Encoder& enc) {
-			auto push_int = [&](const int_t& val) {
-				if (val.fits_si())
-					enc.push_integer(val.to_si());
-				else
-					enc.push_bigint(val.get_str());
-				};
-
-			if constexpr (std::is_same_v<T, rat_t>) {
-				enc.push_function("List", nnz);
-				for (size_t i = 0; i < nnz; i++) {
-					auto& rat_val = tensor.val(i);
-					if (rat_val.is_integer())
-						push_int(rat_val.num());
-					else {
-						// func,2,symbol,8,"Rational"
-						enc.push_ustr("f\x02s\x08Rational");
-						push_int(rat_val.num());
-						push_int(rat_val.den());
-					}
-				}
-			}
-			else if constexpr (std::is_same_v<T, int_t>) {
-				enc.push_function("List", nnz);
-				for (size_t i = 0; i < nnz; i++) {
-					push_int(tensor.val(i));
-				}
-			}
-			else if constexpr (std::is_same_v<T, ulong>) {
-				enc.push_array_info({ nnz }, WXF_HEAD::narray, 19);
-				enc.push_ustr(tensor.data.valptr, tensor.data.valptr + nnz);
-			}
-			};
-
-		Encoder enc = fullform_to_wxf(ff_template, func_map, include_head);
-
-		return enc.buffer;
-	}
-
-	template <typename T, typename index_t>
-	std::vector<uint8_t> sparse_tensor_write_mma_wxf(const sparse_tensor<T, index_t, SPARSE_CSR>& tensor, bool include_head = true) {
+	std::vector<uint8_t> sparse_tensor_write_wxf(const sparse_tensor<T, index_t, SPARSE_CSR>& tensor, bool include_head = true, bool mma_layout = false) {
 		using namespace WXF_PARSER;
 
 		if (tensor.alloc() == 0)
@@ -895,23 +743,40 @@ namespace SparseRREF {
 		std::unordered_map<std::string, std::function<void(Encoder&)>> func_map;
 
 		func_map["#dims"] = [&](Encoder& enc) {
-			auto num_type = WXF_PARSER::minimal_pos_signed_bits(*std::max_element(dims.begin(), dims.end()));
-			enc.push_array({ rank }, std::span(dims), WXF_HEAD::array, num_type);
+			if (mma_layout) {
+				auto num_type = WXF_PARSER::minimal_pos_signed_bits(*std::max_element(dims.begin(), dims.end()));
+				enc.push_array({ rank }, std::span(dims), WXF_HEAD::array, num_type);
+			}
+			else {
+				std::vector<int64_t> dims_legacy(tensor.dims().begin(), tensor.dims().end());
+				enc.push_packed_array({ rank }, dims_legacy);
+			}
 			};
 
 		func_map["#rowptr"] = [&](Encoder& enc) {
 			const auto& rowptr = tensor.data.rowptr;
-			auto num_type = WXF_PARSER::minimal_pos_signed_bits(nnz);
-			enc.push_array({ rowptr.size() }, std::span(rowptr), WXF_HEAD::array, num_type);
+			if (mma_layout) {
+				auto num_type = WXF_PARSER::minimal_pos_signed_bits(nnz);
+				enc.push_array({ rowptr.size() }, std::span(rowptr), WXF_HEAD::array, num_type);
+			}
+			else {
+				enc.push_array({ rowptr.size() }, std::span(rowptr), WXF_HEAD::array, 3);
+			}
 			};
 
 
 		func_map["#colindex"] = [&](Encoder& enc) {
 			auto col_span = std::span(tensor.data.colptr, (rank - 1) * nnz);
-			size_t max_colindex = 0;
-			if (!col_span.empty())
-				max_colindex = static_cast<size_t>(*std::max_element(col_span.begin(), col_span.end())) + 1;
-			auto num_type = WXF_PARSER::minimal_pos_signed_bits(max_colindex);
+			uint8_t num_type = 0;
+			if (mma_layout) {
+				size_t max_colindex = 0;
+				if (!col_span.empty())
+					max_colindex = static_cast<size_t>(*std::max_element(col_span.begin(), col_span.end())) + 1;
+				num_type = WXF_PARSER::minimal_pos_signed_bits(max_colindex);
+			}
+			else {
+				num_type = minimal_pos_signed_bits(1 + *std::max_element(dims.begin() + 1, dims.end()));
+			}
 			enc.push_array({ nnz, rank - 1 }, col_span, WXF_HEAD::array, num_type, [](const index_t& idx) {
 				return idx + 1; // assumes idx + 1 does not exceed std::numeric_limits<index_t>::max()
 				});
@@ -920,11 +785,23 @@ namespace SparseRREF {
 		func_map["#vals"] = [&](Encoder& enc) {
 			if constexpr (std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>) {
 				auto val_span = std::span(tensor.data.valptr, nnz);
-				auto num_type = WXF_HELPER::vals_array_num_type(val_span);
-				if (num_type != 102) {
-					enc.push_array({ nnz }, val_span, WXF_HEAD::array, num_type, [](const T& value) {
-						return WXF_HELPER::value_to_si(value);
-						});
+				if (mma_layout) {
+					auto num_type = WXF_HELPER::vals_array_num_type(val_span);
+					if (num_type != 102) {
+						enc.push_array({ nnz }, val_span, WXF_HEAD::array, num_type, [](const T& value) {
+							return WXF_HELPER::value_to_si(value);
+							});
+					}
+					else {
+						enc.push_function("List", nnz);
+						for (size_t i = 0; i < nnz; i++) {
+							WXF_HELPER::push_value(enc, tensor.val(i));
+						}
+					}
+				}
+				else if constexpr (std::is_same_v<T, ulong>) {
+					enc.push_array_info({ nnz }, WXF_HEAD::narray, 19);
+					enc.push_ustr(tensor.data.valptr, tensor.data.valptr + nnz);
 				}
 				else {
 					enc.push_function("List", nnz);
@@ -933,16 +810,13 @@ namespace SparseRREF {
 					}
 				}
 			}
-			else {
-				static_assert(std::is_same_v<T, rat_t> || std::is_same_v<T, int_t> || std::is_same_v<T, ulong>,
-					"Unsupported SparseRREF WXF value type.");
-			}
 			};
 
 		Encoder enc = fullform_to_wxf(ff_template, func_map, include_head);
 
 		return enc.buffer;
 	}
+
 }
 
 #endif // WXF_SUPPORT_H


### PR DESCRIPTION
Add WXF encoder support and sparse writer logic needed to produce byte-identical `SparseArray` WXF output to Mathematica, while preserving the original SparseRREF WXF layout by default.

CHANGES
- Add in-place buffer construction helpers for generated and transformed binary payloads
- Make integer array writes respect the requested WXF `num_type`
- Add transformed array writing helpers for streaming 1-based indices and packed values
- Add `WXF_HELPER` utilities for scalar fitting, scalar output, and packed value array type selection
- Add `mma_layout` to `sparse_mat_write_wxf` and `sparse_tensor_write_wxf`
- Preserve the original WXF binary layout by default and enable Mathematica byte-identical output with `mma_layout = true`