### PR TITLE
fix some UBs

### DIFF
--- a/sparse_type.h
+++ b/sparse_type.h
@@ -1906,6 +1906,8 @@ namespace SparseRREF {
 			auto nz = nnz();
 			auto n_colptr = s_malloc<index_t>(nz * (rank - 1));
 			auto n_valptr = s_malloc<T>(nz);
+			for (size_t i = 0; i < nz; i++)
+				new (n_valptr + i) T();
 
 			for (size_t i = 0; i < dims[0]; i++) {
 				size_t rownnz = rowptr[i + 1] - rowptr[i];
@@ -1926,6 +1928,8 @@ namespace SparseRREF {
 					});
 				pool->wait();
 			}
+			for (size_t i = 0; i < alloc; i++)
+				valptr[i].~T();
 			s_free(colptr);
 			s_free(valptr);
 			colptr = n_colptr;


### PR DESCRIPTION
Fix some UBs in `sparse_tensor_struct<T, index_t>::sort_indices(thread_pool* pool)`

CHANGES
- Explicitly constructs objects of type `T` in the newly allocated `n_valptr` array using `new` during allocation.
- Explicitly calls the destructor for each object in the `valptr` array before freeing its memory, ensuring proper cleanup of resources.